### PR TITLE
Feature/custom url scrolling logs

### DIFF
--- a/SmartHunter/Game/Config/LocalizationConfig.cs
+++ b/SmartHunter/Game/Config/LocalizationConfig.cs
@@ -315,7 +315,7 @@ namespace SmartHunter.Config
             { "LOC_STATUS_EFFECT_HEALTH_RECOVERY", "Health Recovery" },
             { "LOC_STATUS_EFFECT_HEALTH_BOOST", "Health Boost" },
             { "LOC_STATUS_EFFECT_STAMINA_USE_REDUCED", "Stamina Use Reduced" },
-            
+
             // Debuffs
             { "LOC_STATUS_EFFECT_FIREBLIGHT", "Fireblight" },
             { "LOC_STATUS_EFFECT_THUNDERBLIGHT", "Thunderblight" },
@@ -330,7 +330,7 @@ namespace SmartHunter.Config
             { "LOC_STATUS_EFFECT_NO_ITEMS", "No Items" },
             { "LOC_STATUS_EFFECT_BLASTBLIGHT", "Blastblight" },
             { "LOC_STATUS_EFFECT_BLASTSCOURGE", "Blastscourge" },
-            
+
             // Buffs
             { "LOC_STATUS_EFFECT_DASH_JUICE", "Dash Juice" },
             { "LOC_STATUS_EFFECT_WIGGLY_LITCHI", "Wiggly Litchi" },
@@ -492,7 +492,9 @@ namespace SmartHunter.Config
             { "LOC_SETTING_DEGUB_WIDGET", "Debug Widget"},
             { "LOC_SETTING_DEGUB_WIDGET_DESC", "Show/Hide Debug Widget"},
             { "LOC_SETTING_SHOW_SERVER_LOGS", "Show server logs"},
-            { "LOC_SETTING_SHOW_SERVER_LOGS_DESC", "Show server logs"}
+            { "LOC_SETTING_SHOW_SERVER_LOGS_DESC", "Show server logs"},
+            { "LOC_SETTING_IGNORE_HTTPS_ERRORS", "Ignore server HTTPS certificate errors" },
+            { "LOC_SETTING_IGNORE_HTTPS_ERRORS_DESC", "In case you're hosting server locally and dont have correct certificate configured" }
         };
 
         public LocalizationConfig()

--- a/SmartHunter/Game/Config/MainConfig.cs
+++ b/SmartHunter/Game/Config/MainConfig.cs
@@ -12,7 +12,9 @@ namespace SmartHunter.Game.Config
         public string MonsterDataFileName = "MonsterData.json";
         public string PlayerDataFileName = "PlayerData.json";
         public string MemoryFileName = "Memory.json";
+        public string ServerUrl = "https://peppatime.altervista.org/smarthunter.php";
 
+        public bool IgnoreHttpsErrors = false;
         public bool ShutdownWhenProcessExits = false;
         public bool AutomaticallyCheckAndDownloadUpdates = true; // TODO: Rimetti a true
 

--- a/SmartHunter/Game/Data/ViewModels/SettingsViewModel.cs
+++ b/SmartHunter/Game/Data/ViewModels/SettingsViewModel.cs
@@ -220,6 +220,17 @@ namespace SmartHunter.Game.Data.ViewModels
                 ConfigHelper.Main.Values.Debug.ShowServerLogs = !ConfigHelper.Main.Values.Debug.ShowServerLogs;
                 ConfigHelper.Main.Save();
             })));
+
+            Settings.Add(new Setting(ConfigHelper.Main.Values.IgnoreHttpsErrors, GetString("LOC_SETTING_IGNORE_HTTPS_ERRORS"), GetString("LOC_SETTING_IGNORE_HTTPS_ERRORS_DESC"), new Command(_ =>
+            {
+                ConfigHelper.Main.Values.IgnoreHttpsErrors = !ConfigHelper.Main.Values.IgnoreHttpsErrors;
+                ConfigHelper.Main.Save();
+                var result = MessageBox.Show(GetString("LOC_SETTING_RESTART_DESC"), GetString("LOC_SETTING_RESTART"), MessageBoxButton.YesNo, MessageBoxImage.Information);
+                if (result == MessageBoxResult.Yes)
+                {
+                    restartSmartHunter();
+                }
+            })));
         }
     }
 }

--- a/SmartHunter/Game/Data/WidgetContexts/DebugWidgetContext.cs
+++ b/SmartHunter/Game/Data/WidgetContexts/DebugWidgetContext.cs
@@ -123,13 +123,13 @@ namespace SmartHunter.Game.Data.WidgetContexts
                             {
                                 if (CurrentGame.IsCurrentPlayerLobbyHost())
                                 {
-                                    CurrentGame.checkDone = result["result"]["players"].ToString().Equals("true");
+                                    CurrentGame.checkDone = result["result"]["players"].ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
                                 }
                                 else
                                 {
-                                    CurrentGame.checkDone = result["result"]["host"].ToString().Equals("true");
+                                    CurrentGame.checkDone = result["result"]["host"].ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
                                 }
-                                CurrentGame.playersCheckDone = result["result"]["players"].ToString().Equals("true");
+                                CurrentGame.playersCheckDone = result["result"]["players"].ToString().Equals("true", StringComparison.CurrentCultureIgnoreCase);
                             }
                             else if (result != null && result["status"].ToString().Equals("error"))
                             {

--- a/SmartHunter/Game/Helpers/MhwHelper.cs
+++ b/SmartHunter/Game/Helpers/MhwHelper.cs
@@ -372,7 +372,7 @@ namespace SmartHunter.Game.Helpers
                                 OverlayViewModel.Instance.DebugWidget.Context.CurrentGame.checkDone = false;
                                 OverlayViewModel.Instance.DebugWidget.Context.CurrentGame.playersCheckDone = false;
                             }
-                            else if (result["result"].ToString().Equals("false"))
+                            else if (result["result"].ToString().Equals("false", StringComparison.CurrentCultureIgnoreCase))
                             {
                                 OverlayViewModel.Instance.DebugWidget.Context.CurrentGame.playersCheckDone = false;
                             }
@@ -537,7 +537,7 @@ namespace SmartHunter.Game.Helpers
                                     {
                                         if (result != null && result["status"].ToString().Equals("error"))
                                         {
-                                            if (result["result"].ToString().Equals("false"))
+                                            if (result["result"].ToString().Equals("false", StringComparison.CurrentCultureIgnoreCase))
                                             {
                                                 OverlayViewModel.Instance.DebugWidget.Context.CurrentGame.checkDone = false;
                                             }
@@ -605,7 +605,7 @@ namespace SmartHunter.Game.Helpers
                                     {
                                         if (result["status"].ToString().Equals("error"))
                                         {
-                                            if (result["result"].ToString().Equals("false"))
+                                            if (result["result"].ToString().Equals("false", StringComparison.CurrentCultureIgnoreCase))
                                             {
                                                 OverlayViewModel.Instance.DebugWidget.Context.CurrentGame.checkDone = false;
                                             }

--- a/SmartHunter/SmartHunter.csproj
+++ b/SmartHunter/SmartHunter.csproj
@@ -9,8 +9,8 @@
         <LangVersion>latest</LangVersion>
         <AssemblyTitle>SmartHunter</AssemblyTitle>
         <Deterministic>false</Deterministic>
-        <AssemblyVersion>2020.10.02.03</AssemblyVersion>
-        <FileVersion>2020.10.02.03</FileVersion>
+        <AssemblyVersion>2020.10.11.01</AssemblyVersion>
+        <FileVersion>2020.10.11.01</FileVersion>
         <OutputPath>bin\$(Configuration)</OutputPath>
         <UseWPF>true</UseWPF>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/SmartHunter/Ui/Controls/ScrollingTextBox.cs
+++ b/SmartHunter/Ui/Controls/ScrollingTextBox.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Windows.Controls;
+
+namespace SmartHunter.Ui.Controls
+{
+    /// <summary>
+    /// This textbox will scroll to end when text is changed
+    /// </summary>
+    public class ScrollingTextBox : TextBox {
+
+        protected override void OnInitialized(EventArgs e)
+        {
+            base.OnInitialized(e);
+            VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
+            HorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
+        }
+
+        protected override void OnTextChanged(TextChangedEventArgs e)
+        {
+            base.OnTextChanged(e);
+            CaretIndex = Text.Length;
+            ScrollToEnd();
+        }
+    }
+}

--- a/SmartHunter/Ui/Windows/ConsoleWindow.xaml
+++ b/SmartHunter/Ui/Windows/ConsoleWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:core="clr-namespace:SmartHunter.Core"
         xmlns:viewModels="clr-namespace:SmartHunter.Game.Data.ViewModels"
+        xmlns:controls="clr-namespace:SmartHunter.Ui.Controls"
         d:DataContext="{x:Static viewModels:ConsoleViewModel.Instance}"
         mc:Ignorable="d"
         Title="SmartHunter" Height="450" Width="800"
@@ -21,7 +22,7 @@
 
     <TabControl TabStripPlacement="Top">
         <TabItem Header="Logs" x:Name="LogsTab">
-            <TextBox Text="{Binding Output}" AcceptsReturn="True" TextWrapping="Wrap" IsReadOnly="True" VerticalScrollBarVisibility="Visible" />
+            <controls:ScrollingTextBox Text="{Binding Output}" AcceptsReturn="True" TextWrapping="Wrap" IsReadOnly="True" VerticalScrollBarVisibility="Visible" />
         </TabItem>
         <TabItem Header="Settings" x:Name="SettingsTab">
             <ScrollViewer VerticalScrollBarVisibility="Auto" CanContentScroll="True">


### PR DESCRIPTION
I'm writing my implementation of server because current one is a bit slow and also won't show some statuses correctly. I will create repository for it soon enough. I can commit it to this repository if you think this is appropriate.
For now I just want to introduce ability to specify custom url.

Multiple updates:
- added ability to specify custom url for monster hunter server
- added option to ignore HTTPS errors when connecting to monster hunter server
- boolean server responses are not case-sensitive
- added logs textbox autoscroll to end